### PR TITLE
simplify transferStAur fn and add isAvailable to check stAUR balance

### DIFF
--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -87,28 +87,24 @@ contract LiquidityPool is ERC4626, Ownable {
         fullyOperational = !fullyOperational;
     }
 
+    function isAvailable(uint _amount) view external returns(bool){
+        if (stAurBalance >= _amount) return true;
+        return false;
+    }
+
     /// @dev This function will ONLY be called by the stAUR vault
     /// @dev to cover Aurora deposits (FLOW 1).
     function transferStAur(
         address _receiver,
-        uint256 _amount
-    ) external onlyStAurVault returns (bool) {
-        if (stAurBalance >= _amount) {
-            stAurBalance -= _amount;
-            IStakedAuroraVault(stAurVault).safeTransfer(_receiver, _amount);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /// @dev If stAUR is transfered from the LP {see transferStAur()},
-    /// @dev then Aurora MUST be claimed from the vault (FLOW 1).
-    function getAuroraFromVault(uint256 _assets) external onlyStAurVault {
+        uint256 _amount,
+        uint _assets
+    ) external onlyStAurVault {
+        stAurBalance -= _amount;
+        IStakedAuroraVault(stAurVault).safeTransfer(_receiver, _amount);
         auroraBalance += _assets;
         IERC20(auroraToken).safeTransferFrom(stAurVault, address(this), _assets);
     }
-
+    
     /// @notice The returned amount is denominated in Aurora Tokens.
     /// @dev Return the balance of Aurora and the current value in Aurora for the stAUR balance.
     function totalAssets() public view override returns (uint256) {

--- a/contracts/StakedAuroraVault.sol
+++ b/contracts/StakedAuroraVault.sol
@@ -204,14 +204,12 @@ contract StakedAuroraVault is ERC4626, Ownable {
         IERC20 auroraToken = IERC20(asset());
         IStakingManager manager = IStakingManager(stakingManager);
         auroraToken.safeTransferFrom(_caller, address(this), _assets);
-
         ILiquidityPool pool = ILiquidityPool(liquidityPool);
-        bool stAurTransfered = pool.transferStAur(_receiver, _shares);
 
         // FLOW 1: Use the stAUR in the Liquidity Pool.
-        if (stAurTransfered) {
+        if (pool.isAvailable(_shares)) {
             auroraToken.safeIncreaseAllowance(liquidityPool, _assets);
-            pool.getAuroraFromVault(_assets);
+            pool.transferStAur(_receiver, _shares, _assets);
         // FLOW 2: Stake with the depositor to mint more stAUR.
         } else {
             address depositor = manager.nextDepositor();

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -3,5 +3,6 @@ pragma solidity 0.8.18;
 
 interface ILiquidityPool {
     function getAuroraFromVault(uint256 _assets) external;
-    function transferStAur(address _receiver, uint256 _amount) external returns (bool);
+    function transferStAur(address _receiver, uint256 _amount, uint _assets) external;
+    function isAvailable(uint _amount) external returns(bool);
 }


### PR DESCRIPTION
Unify the transferStAur and getAuroraFromVault functions to prevent Liquidity Pool from depending on StakedAuroraVault calling both.